### PR TITLE
Spread modifier styles inside _getPopperStyle and update example

### DIFF
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -42,6 +42,21 @@ class App extends Component {
             Content Right
             <Arrow/>
           </Popper>
+          <Popper placement="top" modifiers={ {
+                          customStyle: {
+                            enabled: true,
+                            'function': function(data) {
+                              data.styles = {
+                                ...data.styles,
+                                background: 'red',
+                              };
+                              return data
+                            }.bind(this)
+                          },
+                        } }>
+            Custom Style
+            <Arrow/>
+          </Popper>
           <Popper placement={placement}>
             Dynamic Content
             <Arrow/>

--- a/example/main.scss
+++ b/example/main.scss
@@ -10,6 +10,10 @@ html {
   font-family: 'Lato', sans-serif;
 }
 
+select {
+  margin-bottom: 3rem;
+}
+
 .popper {
   background: #222;
   color: white;

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -68,7 +68,9 @@ class Popper extends Component {
     enabled:  true,
     order:    900,
     function: (data) => {
-      if ((this.state.data && !isEqual(data.offsets, this.state.data.offsets)) || !this.state.data) {
+      if (this.state.data && !isEqual(data.offsets, this.state.data.offsets) ||
+          !this.state.data
+      ) {
         this.setState({ data })
       }
     }
@@ -115,9 +117,11 @@ class Popper extends Component {
   }
 
   _getPopperStyle = () => {
+    const { data } = this.state
+
     // If Popper isn't instantiated, hide the popperElement
     // to avoid flash of unstyled content
-    if (!this._popper || !this.state.data) {
+    if (!this._popper || !data) {
       return {
         position:      'absolute',
         pointerEvents: 'none',
@@ -129,8 +133,7 @@ class Popper extends Component {
       top,
       left,
       position,
-    } = this.state.data.offsets.popper
-    const styles = this.state.data.styles
+    } = data.offsets.popper
 
     return {
       position,
@@ -138,7 +141,7 @@ class Popper extends Component {
       left:       0,
       transform:  `translate3d(${left}px, ${top}px, 0px)`,
       willChange: 'transform',
-      ...styles,
+      ...data.styles
     }
   }
 

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -139,6 +139,7 @@ class Popper extends Component {
       left,
       position,
     } = this.state.data.offsets.popper
+    const styles = this.state.data.styles
 
     return {
       position,
@@ -146,6 +147,7 @@ class Popper extends Component {
       left:       0,
       transform:  `translate3d(${left}px, ${top}px, 0px)`,
       willChange: 'transform',
+      ...styles,
     }
   }
 


### PR DESCRIPTION
#### What does this PR do?

Spreads modifier styles inside _getPopperStyle and updates example.

#### Any background context you want to provide?

We ran into this need when working with a react custom Select component where we want the dropdown list width to match that of the trigger.  

The example includes a simpler scenario where we just change the background color.

#### Screenshot

![screen shot 2017-03-09 at 12 32 45 pm](https://cloud.githubusercontent.com/assets/202773/23767116/94c3b8f6-04c4-11e7-8776-0294bd56009d.png)
