### PR TITLE
feat: Make Popper instance available to child context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-popper",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "React wrapper around PopperJS.",
   "main": "lib/react-popper.js",
   "files": [

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -185,7 +185,7 @@ class Popper extends Component {
         style: popperStyle,
         ['data-placement']: popperPlacement,
       }
-      return children({ popperProps, restProps })
+      return children({ popperProps, restProps, popper: this._popper })
     }
 
     return createElement(


### PR DESCRIPTION
This allows this kind of usage:

```
const Demo = ({ close, children }) =>
  <span>
    <Target>👇</Target>
    <Portal>
      <ClickOutside onClickOutside={close}>
        <Popper>
          {({ popper }) =>
            <ResizeAware onResize={popper.scheduleUpdate}>
              {children} 👋
            </ResizeAware>
          }
        </Popper>
      </ClickOutside>
    </Portal>
  </span>
```