### PR TITLE
Pass Popper placement to Arrow

### DIFF
--- a/src/Arrow.jsx
+++ b/src/Arrow.jsx
@@ -11,11 +11,13 @@ const Arrow = (props, context) => {
     }
   }
   const arrowStyle = popper.getArrowStyle()
+  const popperPlacement = popper.getPopperPlacement()
 
   if (typeof children === 'function') {
     const arrowProps = {
       ref: arrowRef,
       style: arrowStyle,
+      ['data-popper-placement']: popperPlacement,
     }
     return children({ arrowProps, restProps })
   }
@@ -29,6 +31,7 @@ const Arrow = (props, context) => {
         ...arrowStyle,
         ...restProps.style,
       },
+      ['data-popper-placement']: popperPlacement,
     },
     children
   )

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -37,6 +37,7 @@ class Popper extends Component {
       popper: {
         setArrowNode: this._setArrowNode,
         getArrowStyle: this._getArrowStyle,
+        getPopperPlacement: this._getPopperPlacement
       },
     }
   }


### PR DESCRIPTION
This PR adds the ability to retrieve the Popper placement from within the `Arrow` component. This makes it easier to style the arrow using Styled Components.

Example:

```js
const StyledArrow = styled(Arrow)`
  ${props => props['data-popper-placement'] === 'right-start' && 'background-color: red;'}
`

const MyPopper = () => (
  <Manager>
    <Popper>
      <StyledArrow />
    </Popper>
  </Manager>
)
```

vs. current situation:

```js
const StyledPopper = styled(Popper)`
  ${props => props['data-placement'] === 'right-start' && '.popper-arrow { background-color: red; }'}
`

const MyPopper = () => (
  <Manager>
    <StyledPopper>
      <Arrow className='popper-arrow' />
    </StyledPopper >
  </Manager>
)
```

I called the prop `data-popper-placement` instead of `data-placement` because it doesn't refer to the placement of the arrow itself.