### PR TITLE
Fix needed to properly work with Popper.js 1.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-popper",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "React wrapper around PopperJS.",
   "main": "lib/react-popper.js",
   "files": [
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "is-equal-shallow": "^0.1.3",
-    "popper.js": "^1.9.9",
+    "popper.js": "^1.10.1",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -139,10 +139,6 @@ class Popper extends Component {
 
     return {
       position,
-      top: 0,
-      left: 0,
-      transform: `translate3d(${Math.round(left)}px, ${Math.round(top)}px, 0px)`,
-      willChange: 'transform',
       ...data.styles,
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,9 +3009,9 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-popper.js@^1.9.9:
-  version "1.9.9"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.9.9.tgz#bcc8d2e4e40fa0ce26ce33ee0f9f8e7ad8c75809"
+popper.js@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.10.1.tgz#57f2950589f53ffa5837cd44af149487c17f3835"
 
 portfinder@0.4.x:
   version "0.4.0"
@@ -3291,16 +3291,9 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-
-prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
-  version "15.5.9"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"


### PR DESCRIPTION
Popper.js 1.10.1 added two new options to the new `computeStyle` modifier, now the poppers can be positioned using a different offset origin (`bottom: 0` or `left: 0` instead of the usual `top` and `left`).

To make the new options work properly you have to get rid of all the manual styles computation and simply take what Popper.js provides.