### PR TITLE
Fix scheduleUpdate call if this._popper does not exist

### DIFF
--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -53,7 +53,7 @@ class Popper extends Component {
       this._updatePopper()
     }
 
-    if (lastProps.children !== this.props.children) {
+    if (this._popper && lastProps.children !== this.props.children) {
       this._popper.scheduleUpdate()
     }
   }


### PR DESCRIPTION
Refs #32

Defensive PR to avoid error if `this._popper` not defined. Should inspect to understand why not defined in the first place, but really needed to fix it for my project.

Merge if it helps =)

Best