### PR TITLE
Fix missing data-x-out-of-boundaries attribute

### DIFF
--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -147,6 +147,10 @@ class Popper extends Component {
     return !!this.state.data ? this.state.data.placement : undefined
   }
 
+  _getPopperHide = () => {
+    return !!this.state.data && this.state.data.hide ? '' : undefined
+  }
+
   _getArrowStyle = () => {
     if (!this.state.data || !this.state.data.offsets.arrow) {
       return {}
@@ -175,12 +179,14 @@ class Popper extends Component {
     }
     const popperStyle = this._getPopperStyle()
     const popperPlacement = this._getPopperPlacement()
+    const popperHide = this._getPopperHide()
 
     if (typeof children === 'function') {
       const popperProps = {
         ref: popperRef,
         style: popperStyle,
         ['data-placement']: popperPlacement,
+        ['data-x-out-of-boundaries']: popperHide,
       }
       return children({
         popperProps,
@@ -196,6 +202,7 @@ class Popper extends Component {
         ...popperStyle,
       },
       'data-placement': popperPlacement,
+      'data-x-out-of-boundaries': popperHide,
     }
 
     if (typeof component === 'string') {


### PR DESCRIPTION
### Current behavior
No support for https://popper.js.org/popper-documentation.html#modifiers..hide.

### Expected behavior
Full support for `modifiers.hide`, specifically that the `data-x-out-of-boundaries` attribute is passed along.

### Changes
Passes along the `data-x-out-of-boundaries` attribute in a similar manner to `data-placement`.

### Why
We needed this in our app. More importantly, we saw no reason a wrapper around Popper shouldn’t support this.

### How this has been tested
Confirmed `build` still works. Confirmed expected example behavior when running `dev` after modifying the Popper config like so:

```js
const modifiers = {
  customStyle: {
    // ...unchanged
  },
  preventOverflow: {
    boundariesElement: 'viewport',
  },
  hide: {
    enabled: true,
  },
}
```