### PR TITLE
Update to use latest typings from popper.js

### DIFF
--- a/react-popper.d.ts
+++ b/react-popper.d.ts
@@ -1,6 +1,6 @@
 declare module "react-popper" {
   import * as React from "react";
-  import * as PopperJS from "popper.js";
+  import PopperJS from "popper.js";
 
   interface IRestProps {
     restProps: {


### PR DESCRIPTION
The typings in popper.js were [updated recently](https://github.com/FezVrasta/popper.js/pull/367#issuecomment-319449475), causing issues. I believe this fix is sufficient and so does the [update's author](https://github.com/FezVrasta/popper.js/pull/367#issuecomment-319674674) but I would like to verify with someone if this is the right step.