### PR TITLE
Update how react-popper.d.ts imports PopperJS

### DIFF
--- a/react-popper.d.ts
+++ b/react-popper.d.ts
@@ -1,6 +1,6 @@
 declare module "react-popper" {
   import * as React from "react";
-  import * as PopperJS from "popper.js";
+  import PopperJS from "popper.js";
 
   interface IRestProps {
     restProps: {


### PR DESCRIPTION
`popper.js`'s TypeScript definition now exports default, so it's now throwing an error when importing with `* as PopperJS from "popper.js"`. This is a small bug, but it prevents anyone using TypeScript from building their application.