### PR TITLE
Only pass restProps to user-defined component

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ const PopperExample = () => (
 #### `component`: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
 
 A valid DOM tag or custom component to render. If using a custom component, an `innerRef` prop will be passed down that **must** be attached to the child component ref.
+Defaults to 'div'.
+
+#### `componentProps`: PropTypes.object
+
+Additional props to be passed to the corresponding DOM tag `component` along with `style`, `data-placement`, and `ref || innerRef`.
+
+```js
+<Popper component="a" componentProps={{href: 'google.com'}}>
+  ...
+</Popper>
+```
 
 #### `innerRef`: PropTypes.func
 

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -16,6 +16,7 @@ class Popper extends Component {
 
   static propTypes = {
     component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    componentProps: PropTypes.object,
     innerRef: PropTypes.func,
     placement: PropTypes.oneOf(PopperJS.placements),
     eventsEnabled: PropTypes.bool,
@@ -159,6 +160,7 @@ class Popper extends Component {
   render() {
     const {
       component,
+      componentProps: defaultComponentProps,
       innerRef,
       placement,
       eventsEnabled,
@@ -189,20 +191,18 @@ class Popper extends Component {
       })
     }
 
-    const componentProps = {
-      ...restProps,
+    const baseComponentProps = {
       style: {
         ...restProps.style,
         ...popperStyle,
       },
       'data-placement': popperPlacement,
+      ...defaultComponentProps
     }
 
-    if (typeof component === 'string') {
-      componentProps.ref = popperRef
-    } else {
-      componentProps.innerRef = popperRef
-    }
+    const componentProps = typeof component.type === 'string'
+      ? { ...baseComponentProps, ref: popperRef }
+      : { ...baseComponentProps, ...restProps, innerRef: popperRef }
 
     return createElement(component, componentProps, children)
   }


### PR DESCRIPTION
This will prevent unused and incompatible props from being passed inadvertently to the `component` of the Popper. 

Addresses: #52