### PR TITLE
allow React 16 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "homepage": "https://github.com/souporserious/react-popper",
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0",
-    "react-dom": "0.14.x || ^15.0.0"
+    "react": "0.14.x || ^15.0.0 || ^16.0.0",
+    "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "popper.js": "^1.12.5",


### PR DESCRIPTION
This will allow consumers to use `react-popper` with React 16.

I didn't update the devDependency version of React 16 in this PR, although I did in my fork and everything appeared to work correctly.