### PR TITLE
Updates TypeScript definition for IPopperChildrenProps

### DIFF
--- a/react-popper.d.ts
+++ b/react-popper.d.ts
@@ -28,7 +28,9 @@ declare module "react-popper" {
       ref: (ref: HTMLElement) => void;
       style: React.CSSProperties;
       ["data-placement"]: PopperJS.Placement;
-    }
+    },
+    restProps: IRestProps;
+    scheduleUpdate: (() => void) | undefined;
   }
 
   interface IPopperProps extends IComponentProps<IPopperChildrenProps> {

--- a/react-popper.d.ts
+++ b/react-popper.d.ts
@@ -28,7 +28,7 @@ declare module "react-popper" {
       ref: (ref: HTMLElement) => void;
       style: React.CSSProperties;
       ["data-placement"]: PopperJS.Placement;
-    },
+    };
     restProps: IRestProps;
     scheduleUpdate: (() => void) | undefined;
   }


### PR DESCRIPTION
Both `restProps` and `scheduleUpdate` properties were missing from the render function parameter type.