### PR TITLE
make Popper child match parent (Target) width

### DIFF
--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -147,10 +147,10 @@ class Popper extends Component {
     }
 
     const { top, left, position } = data.offsets.popper
-
     return {
       position,
       ...data.styles,
+      ...{width: data.offsets.reference.width}
     }
   }
 


### PR DESCRIPTION
When used with some portal library (mounting element to separate body tree) the width of popper does not match target. This pr solves it. You can still manually set width of Popper child if needed.