### PR TITLE
Pass the placement directly to the Arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ An `Arrow`'s child may be one of the following:
     arrowProps: {
       ref, // a function that accepts the arrow component as an argument
       style // the styles to apply to the arrow element
+      ['data-placement'] // the placement of the Popper
     },
     restProps // any other props that came through the Arrow component
   }

--- a/src/Arrow.jsx
+++ b/src/Arrow.jsx
@@ -11,16 +11,19 @@ const Arrow = (props, context) => {
     }
   }
   const arrowStyle = popper.getArrowStyle()
+  const popperPlacement = popper.getPlacement()
 
   if (typeof children === 'function') {
     const arrowProps = {
       ref: arrowRef,
       style: arrowStyle,
+      ['data-placement']: popperPlacement,
     }
     return children({ arrowProps, restProps })
   }
 
   const componentProps = {
+    ['data-placement']: popperPlacement,
     ...restProps,
     style: {
       ...arrowStyle,

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -36,6 +36,7 @@ class Popper extends Component {
       popper: {
         setArrowNode: this._setArrowNode,
         getArrowStyle: this._getArrowStyle,
+        getPlacement: this._getPopperPlacement,
       },
     }
   }


### PR DESCRIPTION
This is useful for `Arrow` implemented with `styled-components` for instance (which can style the arrow based on the attribute instead of having to set some classes.