### PR TITLE
Pass target directly to popper

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,51 +77,11 @@ const PopperExample = () => (
 )
 ```
 
-## Usage with opening and closing
-
-This example demonstrates opening and closing a Popper component using state.
-
-```js
-import { PureComponent } from 'react'
-import { Manager, Target, Popper, Arrow } from 'react-popper'
-
-class OpenableExample extends PureComponent {
-  state = {
-    isOpen: false,
-  }
-
-  handleClick = () => {
-    this.setState(prevState => ({
-      isOpen: !prevState.isOpen
-    }))
-  }
-
-  render() {
-    return (
-      <Manager>
-        <Target
-          style={{ width: 120, height: 120, background: '#b4da55' }}
-          onClick={this.handleClick}
-        >
-          Click {this.state.isOpen ? 'to hide' : 'to show'} popper
-        </Target>
-        {this.state.isOpen && (
-          <Popper className="popper">
-            Popper Content
-            <Arrow className="popper__arrow"/>
-          </Popper>
-        )}
-      </Manager>
-    )
-  }
-}
-```
-
 ## Usage without Manager
 
 It's generally easiest to let the `Manager` and `Target` components handle passing the target DOM element to the `Popper` component. However, you can pass a target [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or a [referenceObject](https://popper.js.org/popper-documentation.html#referenceObject) directly into `Popper` if you need to.
 
-Handling DOM Elements from React can be complicated, and is generally discouraged. This example doesn't touch on many common pitfalls and edge cases. The `Manager` and `Target` components handle these complexities for you, so their use is strongly recommended.
+Handling DOM Elements from React can be complicated. The `Manager` and `Target` components handle these complexities for you, so their use is strongly recommended when using DOM Elements.
 
 ```js
 import { PureComonent } from 'react'

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ class OpenableExample extends PureComponent {
 
 ## Usage without Manager
 
-It's generally easiest to let the `Manager` and `Target` components handle passing the target DOM element to the `Popper` component. However, you can pass the target [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) directly into `Popper` if you need to.
+It's generally easiest to let the `Manager` and `Target` components handle passing the target DOM element to the `Popper` component. However, you can pass a target [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or a [referenceObject](https://popper.js.org/popper-documentation.html#referenceObject) directly into `Popper` if you need to.
 
 Handling DOM Elements from React can be complicated, and is generally discouraged. This example doesn't touch on many common pitfalls and edge cases. The `Manager` and `Target` components handle these complexities for you, so their use is strongly recommended.
 
@@ -212,7 +212,7 @@ Each `Popper` must either be wrapped in a `Manager`, or passed a `target` prop d
 #### `placement`: PropTypes.oneOf(Popper.placements)
 #### `eventsEnabled`: PropTypes.bool
 #### `modifiers`: PropTypes.object
-#### `target`: PropTypes.instanceOf(Element)
+#### `target`: PropTypes.oneOfType([PropTypes.instanceOf(Element), Popper.referenceObject])
 
 Passes respective options to a new [Popper instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options). As for `onCreate` and `onUpdate`, these callbacks were intentionally left out in favor of using the [component lifecycle methods](https://facebook.github.io/react/docs/react-component.html#the-component-lifecycle). If you have a good use case for these please feel free to file and issue and I will consider adding them in.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const PopperExample = () => (
 )
 ```
 
-## Usage w/ child function
+## Usage with child function
 
 This is a useful way to interact with custom components. Just make sure you pass down the refs properly.
 
@@ -75,6 +75,89 @@ const PopperExample = () => (
     </Popper>
   </Manager>
 )
+```
+
+## Usage with opening and closing
+
+This example demonstrates opening and closing a Popper component using state.
+
+```js
+import { PureComponent } from 'react'
+import { Manager, Target, Popper, Arrow } from 'react-popper'
+
+class OpenableExample extends PureComponent {
+  state = {
+    isOpen: false,
+  }
+
+  handleClick = () => {
+    this.setState(prevState => ({
+      isOpen: !prevState.isOpen
+    }))
+  }
+
+  render() {
+    return (
+      <Manager>
+        <Target
+          style={{ width: 120, height: 120, background: '#b4da55' }}
+          onClick={this.handleClick}
+        >
+          Click {this.state.isOpen ? 'to hide' : 'to show'} popper
+        </Target>
+        {this.state.isOpen && (
+          <Popper className="popper">
+            Popper Content
+            <Arrow className="popper__arrow"/>
+          </Popper>
+        )}
+      </Manager>
+    )
+  }
+}
+```
+
+## Usage without Manager
+
+It's generally easiest to let the `Manager` and `Target` components handle passing the target DOM element to the `Popper` component. However, you can pass the target [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) directly into `Popper` if you need to.
+
+Handling DOM Elements from React can be complicated, and is generally discouraged. This example doesn't touch on many common pitfalls and edge cases. The `Manager` and `Target` components handle these complexities for you, so their use is strongly recommended.
+
+```js
+import { PureComonent } from 'react'
+import { Popper, Arrow } from 'react-popper'
+
+class StandaloneExample extends PureComponent {
+  state = {
+    isOpen: false,
+  }
+
+  handleClick() = () => {
+    this.setState(prevState => ({
+      isOpen: !prevState.isOpen
+    }))
+  }
+
+  render() {
+    return (
+      <div>
+        <div
+          ref={(div) => this.target = div}
+          style={{ width: 120, height: 120, background: '#b4da55' }}
+          onClick={this.handleClick}
+        >
+          Click {this.state.isOpen ? 'to hide' : 'to show'} popper
+        </div>
+        {this.state.isOpen && (
+          <Popper className="popper" target={this.target}>
+            Popper Content
+            <Arrow className="popper__arrow"/>
+          </Popper>
+        )}
+      </div>
+    )
+  }
+}
 ```
 
 ## `Shared Props`
@@ -124,11 +207,12 @@ A `Target`'s child may be one of the following:
 
 Your popper that gets attached to the `Target` component.
 
-Each `Popper` must be wrapped in a `Manager`, and each `Manager` can wrap multiple `Popper` components.
+Each `Popper` must either be wrapped in a `Manager`, or passed a `target` prop directly. Each `Manager` can wrap multiple `Popper` components.
 
 #### `placement`: PropTypes.oneOf(Popper.placements)
 #### `eventsEnabled`: PropTypes.bool
 #### `modifiers`: PropTypes.object
+#### `target`: PropTypes.instanceOf(Element)
 
 Passes respective options to a new [Popper instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options). As for `onCreate` and `onUpdate`, these callbacks were intentionally left out in favor of using the [component lifecycle methods](https://facebook.github.io/react/docs/react-component.html#the-component-lifecycle). If you have a good use case for these please feel free to file and issue and I will consider adding them in.
 

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom'
 import MultipleExample from './multiple'
 import AnimatedExample from './animated'
 import ModifiersExample from './modifiers'
-import OpenableExample from './openable'
+import ToggleableExample from './toggleable'
 import StandaloneExample from './standalone'
 import StandaloneObjectExample from './standaloneObject'
 
@@ -22,7 +22,7 @@ const App = () => (
       <ModifiersExample />
     </div>
     <div style={{ marginBottom: 200 }}>
-      <OpenableExample />
+      <ToggleableExample />
     </div>
     <div style={{ marginBottom: 200 }}>
       <StandaloneExample />

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -6,6 +6,7 @@ import AnimatedExample from './animated'
 import ModifiersExample from './modifiers'
 import OpenableExample from './openable'
 import StandaloneExample from './standalone'
+import StandaloneObjectExample from './standaloneObject'
 
 import './main.css'
 
@@ -25,6 +26,9 @@ const App = () => (
     </div>
     <div style={{ marginBottom: 200 }}>
       <StandaloneExample />
+    </div>
+    <div style={{ marginBottom: 200 }}>
+      <StandaloneObjectExample />
     </div>
   </div>
 )

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom'
 import MultipleExample from './multiple'
 import AnimatedExample from './animated'
 import ModifiersExample from './modifiers'
+import OpenableExample from './openable'
+import StandaloneExample from './standalone'
 
 import './main.css'
 
@@ -17,6 +19,12 @@ const App = () => (
     </div>
     <div style={{ marginBottom: 200 }}>
       <ModifiersExample />
+    </div>
+    <div style={{ marginBottom: 200 }}>
+      <OpenableExample />
+    </div>
+    <div style={{ marginBottom: 200 }}>
+      <StandaloneExample />
     </div>
   </div>
 )

--- a/example/openable.jsx
+++ b/example/openable.jsx
@@ -1,0 +1,38 @@
+import React, { PureComponent } from 'react'
+import { Manager, Target, Popper, Arrow } from '../src/react-popper'
+
+class OpenableExample extends PureComponent {
+  state = {
+    isOpen: false,
+  }
+
+  handleClick = () => {
+    this.setState(prevState => ({
+      isOpen: !prevState.isOpen,
+    }))
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>Openable Popper Example</h2>
+        <Manager>
+          <Target
+            style={{ width: 120, height: 120, background: '#b4da55' }}
+            onClick={this.handleClick}
+          >
+            Click {this.state.isOpen ? 'to hide' : 'to show'} popper
+          </Target>
+          {this.state.isOpen && (
+            <Popper className="popper">
+              Popper Content for Openable Example
+              <Arrow className="popper__arrow" />
+            </Popper>
+          )}
+        </Manager>
+      </div>
+    )
+  }
+}
+
+export default OpenableExample

--- a/example/standalone.jsx
+++ b/example/standalone.jsx
@@ -1,0 +1,37 @@
+import React, { PureComponent } from 'react'
+import { Popper, Arrow } from '../src/react-popper'
+
+class StandaloneExample extends PureComponent {
+  state = {
+    isOpen: false,
+  }
+
+  handleClick = () => {
+    this.setState(prevState => ({
+      isOpen: !prevState.isOpen,
+    }))
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>Standalone Popper Example</h2>
+        <div
+          ref={div => (this.target = div)}
+          style={{ width: 120, height: 120, background: '#b4da55' }}
+          onClick={this.handleClick}
+        >
+          Click {this.state.isOpen ? 'to hide' : 'to show'} popper
+        </div>
+        {this.state.isOpen && (
+          <Popper className="popper" target={this.target}>
+            Popper Content for Standalone example
+            <Arrow className="popper__arrow" />
+          </Popper>
+        )}
+      </div>
+    )
+  }
+}
+
+export default StandaloneExample

--- a/example/standaloneObject.jsx
+++ b/example/standaloneObject.jsx
@@ -1,0 +1,48 @@
+import React, { PureComponent } from 'react'
+import { Popper, Arrow } from '../src/react-popper'
+
+class StandaloneObjectExample extends PureComponent {
+  state = {
+    isOpen: false,
+  }
+
+  handleClick = () => {
+    this.setState(prevState => ({
+      isOpen: !prevState.isOpen,
+    }))
+  }
+
+  render() {
+    const reference = {
+      getBoundingClientRect: () => ({
+        top: 10,
+        left: 100,
+        right: 150,
+        bottom: 90,
+        width: 50,
+        height: 80,
+      }),
+      clientWidth: 50,
+      clientHeight: 80,
+    }
+    return (
+      <div>
+        <h2>Standalone referenceObject Popper Example</h2>
+        <div
+          style={{ width: 120, height: 120, background: '#b4da55' }}
+          onClick={this.handleClick}
+        >
+          Click {this.state.isOpen ? 'to hide' : 'to show'} popper
+        </div>
+        {this.state.isOpen && (
+          <Popper className="popper" target={reference}>
+            Popper Content for Standalone example
+            <Arrow className="popper__arrow" />
+          </Popper>
+        )}
+      </div>
+    )
+  }
+}
+
+export default StandaloneObjectExample

--- a/example/toggleable.jsx
+++ b/example/toggleable.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import { Manager, Target, Popper, Arrow } from '../src/react-popper'
 
-class OpenableExample extends PureComponent {
+class ToggleableExample extends PureComponent {
   state = {
     isOpen: false,
   }
@@ -15,7 +15,7 @@ class OpenableExample extends PureComponent {
   render() {
     return (
       <div>
-        <h2>Openable Popper Example</h2>
+        <h2>Toggleable Popper Example</h2>
         <Manager>
           <Target
             style={{ width: 120, height: 120, background: '#b4da55' }}
@@ -25,7 +25,7 @@ class OpenableExample extends PureComponent {
           </Target>
           {this.state.isOpen && (
             <Popper className="popper">
-              Popper Content for Openable Example
+              Popper Content for Toggleable Example
               <Arrow className="popper__arrow" />
             </Popper>
           )}
@@ -35,4 +35,4 @@ class OpenableExample extends PureComponent {
   }
 }
 
-export default OpenableExample
+export default ToggleableExample

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -4,7 +4,7 @@ import PopperJS from 'popper.js'
 
 class Popper extends Component {
   static contextTypes = {
-    popperManager: PropTypes.object.isRequired,
+    popperManager: PropTypes.object,
   }
 
   static childContextTypes = {
@@ -18,6 +18,7 @@ class Popper extends Component {
     eventsEnabled: PropTypes.bool,
     modifiers: PropTypes.object,
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    target: PropTypes.instanceOf(Element),
   }
 
   static defaultProps = {
@@ -60,6 +61,9 @@ class Popper extends Component {
   }
 
   _getTargetNode = () => {
+    if (this.props.target) {
+      return this.props.target
+    }
     return this.context.popperManager.getTargetNode()
   }
 

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -49,7 +49,8 @@ class Popper extends Component {
   componentDidUpdate(lastProps) {
     if (
       lastProps.placement !== this.props.placement ||
-      lastProps.eventsEnabled !== this.props.eventsEnabled
+      lastProps.eventsEnabled !== this.props.eventsEnabled ||
+      lastProps.target !== this.props.target
     ) {
       this._destroyPopper()
       this._createPopper()

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -63,6 +63,13 @@ class Popper extends Component {
   _getTargetNode = () => {
     if (this.props.target) {
       return this.props.target
+    } else if (
+      !this.context.popperManager ||
+      !this.context.popperManager.getTargetNode()
+    ) {
+      throw new Error(
+        'Target missing. Popper must be given a target from the Popper Manager, or as a prop.',
+      )
     }
     return this.context.popperManager.getTargetNode()
   }

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -18,7 +18,14 @@ class Popper extends Component {
     eventsEnabled: PropTypes.bool,
     modifiers: PropTypes.object,
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-    target: PropTypes.instanceOf(Element),
+    target: PropTypes.oneOfType([
+      PropTypes.instanceOf(Element),
+      PropTypes.shape({
+        getBoundingClientRect: PropTypes.func.isRequired,
+        clientWidth: PropTypes.number.isRequired,
+        clientHeight: PropTypes.number.isRequired,
+      }),
+    ]),
   }
 
   static defaultProps = {


### PR DESCRIPTION
Allows passing in a `target` prop to the Popper component directly, bypassing the need for the `Manager` and `Target` components. I implemented this feature for personal use initially, as it was needed in the development of a custom UI library.

The documentation and examples have been updated. I did try to make clear that the `Manager` and `Target` pattern is recommended and easier to use, and should be preferred in most cases.

It was challenging to think of a good example for this feature. I saw two options; get a `ref` and use that, or get an element directly from the DOM. I didn't want to do the latter, because it's generally recommended to avoid that when using React. But the `ref` was problematic as well. If I just grabbed a ref and used it right away, the resulting component would fail to pass in a `target` prop on the first render, because the ref doesn't get called until after the child component mounts. I considered briefly just using `forceUpdate` to trigger a second render in `componentDidMount`, but that was too confusing for an example.

Instead, I side-stepped the issue by writing an example that defaulted to not showing the popper component at all. That avoids the ref issue, because the popper is always hidden on first render, so it doesn't need to be shown. However, this gave me another concern - that people would look at the README for a quick example of how to make an open/close-able popover and grab that example without considering whether using `Manager` would suit their use case better. So to avoid that circumstance, I also added an example doing the same thing with `Manager` and `Target` first.