### PR TITLE
fix: minified umd build without prop-types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,5 @@
 {
-  "presets": [
-    ["env"],
-    "react"
-  ],
+  "presets": ["env", "react"],
   "plugins": [
     "transform-object-rest-spread",
     "transform-class-properties",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,13 @@
     "precommit": "lint-staged",
     "format": "npm run lint -- --fix --quiet",
     "lint": "eslint --ext .js,.jsx src/ example/",
-    "build:lib": "babel src --out-dir lib",
-    "build": "npm run build:lib && cross-env NODE_ENV=production webpack --config webpack.prod.config.js",
     "dev": "webpack-dev-server --hot --progress --host 0.0.0.0",
-    "postbuild": "cross-env NODE_ENV=production && cross-env TARGET=minify webpack --config webpack.prod.config.js",
+    "build": "npm run build:lib && npm run build:umd && npm run build:umd-min",
+    "build:lib": "babel src --out-dir lib",
+    "build:umd":
+      "cross-env NODE_ENV=development webpack --config webpack.umd.config.js",
+    "build:umd-min":
+      "cross-env NODE_ENV=production TARGET=minify webpack --config webpack.umd.config.js",
     "prebuild": "rimraf dist && mkdir dist",
     "prepare": "npm run build"
   },
@@ -61,7 +64,9 @@
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-inline-environment-variables": "^0.3.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.16.0",
     "cross-env": "^5.0.5",

--- a/src/Arrow.jsx
+++ b/src/Arrow.jsx
@@ -37,11 +37,16 @@ const Arrow = (props, context) => {
   return createElement(component, componentProps, children)
 }
 
-Arrow.contextTypes = {
-  popper: PropTypes.object.isRequired,
-}
+Arrow.contextTypes =
+  process.env.NODE_ENV !== 'production'
+    ? {
+        popper: PropTypes.object.isRequired,
+      }
+    : {
+        popper: () => {},
+      }
 
-Arrow.propTypes = {
+Arrow.propTypes /* remove-proptypes */ = {
   component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   innerRef: PropTypes.func,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),

--- a/src/Manager.jsx
+++ b/src/Manager.jsx
@@ -2,9 +2,13 @@ import { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
 
 class Manager extends Component {
-  static childContextTypes = {
-    popperManager: PropTypes.object.isRequired,
-  }
+  static childContextTypes = process.env.NODE_ENV !== 'production'
+    ? {
+        popperManager: PropTypes.object.isRequired,
+      }
+    : {
+        popperManager: () => {},
+      }
 
   static propTypes = {
     tag: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),

--- a/src/Popper.jsx
+++ b/src/Popper.jsx
@@ -3,13 +3,21 @@ import PropTypes from 'prop-types'
 import PopperJS from 'popper.js'
 
 class Popper extends Component {
-  static contextTypes = {
-    popperManager: PropTypes.object.isRequired,
-  }
+  static contextTypes = process.env.NODE_ENV !== 'production'
+    ? {
+        popperManager: PropTypes.object.isRequired,
+      }
+    : {
+        popperManager: () => {},
+      }
 
-  static childContextTypes = {
-    popper: PropTypes.object.isRequired,
-  }
+  static childContextTypes = process.env.NODE_ENV !== 'production'
+    ? {
+        popper: PropTypes.object.isRequired,
+      }
+    : {
+        popper: () => {},
+      }
 
   static propTypes = {
     component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),

--- a/src/Target.jsx
+++ b/src/Target.jsx
@@ -29,11 +29,16 @@ const Target = (props, context) => {
   return createElement(component, componentProps, children)
 }
 
-Target.contextTypes = {
-  popperManager: PropTypes.object.isRequired,
-}
+Target.contextTypes =
+  process.env.NODE_ENV !== 'production'
+    ? {
+        popperManager: PropTypes.object.isRequired,
+      }
+    : {
+        popperManager: () => {},
+      }
 
-Target.propTypes = {
+Target.propTypes /* remove-proptypes */ = {
   component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   innerRef: PropTypes.func,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),

--- a/webpack.umd.config.js
+++ b/webpack.umd.config.js
@@ -3,34 +3,12 @@ var webpack = require('webpack')
 var banner = require('./webpack.banner')
 var TARGET = process.env.TARGET || null
 
-const externals = {
-  react: {
-    root: 'React',
-    commonjs2: 'react',
-    commonjs: 'react',
-    amd: 'react',
-  },
-  'react-dom': {
-    root: 'ReactDOM',
-    commonjs2: 'react-dom',
-    commonjs: 'react-dom',
-    amd: 'react-dom',
-  },
-  'prop-types': {
-    root: 'PropTypes',
-    commonjs2: 'prop-types',
-    commonjs: 'prop-types',
-    amd: 'prop-types',
-  },
-}
-
 var config = {
   entry: './src/react-popper.js',
   output: {
     path: path.join(__dirname, 'dist'),
     publicPath: 'dist/',
     filename: 'react-popper.js',
-    sourceMapFilename: 'react-popper.sourcemap.js',
     library: 'ReactPopper',
     libraryTarget: 'umd',
   },
@@ -40,6 +18,17 @@ var config = {
         exclude: /node_modules/,
         test: /\.(js|jsx)/,
         loader: 'babel-loader',
+        options: {
+          plugins: [
+            [
+              'transform-react-remove-prop-types',
+              {
+                mode: 'wrap',
+              },
+            ],
+            'transform-inline-environment-variables',
+          ],
+        },
       },
     ],
   },
@@ -47,12 +36,30 @@ var config = {
   resolve: {
     extensions: ['.js', '.jsx'],
   },
-  externals: externals,
+  externals: {
+    react: {
+      root: 'React',
+      commonjs2: 'react',
+      commonjs: 'react',
+      amd: 'react',
+    },
+    'react-dom': {
+      root: 'ReactDOM',
+      commonjs2: 'react-dom',
+      commonjs: 'react-dom',
+      amd: 'react-dom',
+    },
+    'prop-types': {
+      root: 'PropTypes',
+      commonjs2: 'prop-types',
+      commonjs: 'prop-types',
+      amd: 'prop-types',
+    },
+  },
 }
 
 if (TARGET === 'minify') {
   config.output.filename = 'react-popper.min.js'
-  config.output.sourceMapFilename = 'react-popper.min.js'
   config.plugins.push(
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,6 +852,10 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-inline-environment-variables@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.3.0.tgz#b9e1929535480e72a9e37210df99aebca007a7b5"
+
 babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
@@ -886,6 +890,10 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-helper-builder-react-jsx "^6.24.1"
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-remove-prop-types@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.13.tgz#331cfc05099a808238311d78319c27460d481189"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"


### PR DESCRIPTION
Fix #80 

I had a hard time finding that the `cross-env` usage for the minified version was one of the problems.

`cross-env NODE_ENV=production && cross-env TARGET=minify webpack` is not setting `NODE_ENV` for webpack

`cross-env NODE_ENV=production TARGET=minify webpack` is the proper way to use `cross-env`