### PR TITLE
Moved import statements out of module declaration

### DIFF
--- a/react-popper.d.ts
+++ b/react-popper.d.ts
@@ -1,6 +1,7 @@
+import * as React from "react";
+import PopperJS from "popper.js";
+
 declare module "react-popper" {
-  import * as React from "react";
-  import PopperJS from "popper.js";
 
   interface IRestProps {
     restProps: {


### PR DESCRIPTION
In my opinion the imports of react and popper.js have to be outside of "react-popper" module declaration.

This will result in problems for example with my fuse box dev server.