### PR TITLE
fix for compilation error 'Cannot find namespace PopperJS'

### DIFF
--- a/react-popper.d.ts
+++ b/react-popper.d.ts
@@ -1,6 +1,6 @@
 declare module "react-popper" {
   import * as React from "react";
-  import PopperJS from "popper.js";
+  import * as PopperJS from "popper.js";
 
   interface IRestProps {
     restProps: {


### PR DESCRIPTION
When you compile the current code with TS 2.6.2 (didn't try others, and at least with allowSyntheticDefaultImports set to false) it gives the following errors:
```
build/0/compileTypescript/0  node_modules/react-popper/react-popper.d.ts(30,27): error TS2503: Cannot find namespace 'PopperJS'.
build/0/compileTypescript/0
build/0/compileTypescript/0  30       ["data-placement"]: PopperJS.Placement;
build/0/compileTypescript/0                               ~~~~~~~~
build/0/compileTypescript/0
build/0/compileTypescript/0
build/0/compileTypescript/0  node_modules/react-popper/react-popper.d.ts(38,17): error TS2503: Cannot find namespace 'PopperJS'.
build/0/compileTypescript/0
build/0/compileTypescript/0  38     modifiers?: PopperJS.Modifiers;
build/0/compileTypescript/0                     ~~~~~~~~
build/0/compileTypescript/0
build/0/compileTypescript/0
build/0/compileTypescript/0  node_modules/react-popper/react-popper.d.ts(39,17): error TS2503: Cannot find namespace 'PopperJS'.
build/0/compileTypescript/0
build/0/compileTypescript/0  39     placement?: PopperJS.Placement;
```
This little fix fixed that.