### PR TITLE
Update Popper Typings

### DIFF
--- a/react-popper.d.ts
+++ b/react-popper.d.ts
@@ -1,6 +1,6 @@
 declare module "react-popper" {
   import * as React from "react";
-  import PopperJS from "popper.js";
+  import * as PopperJS from "popper.js";
 
   interface IRestProps {
     restProps: {


### PR DESCRIPTION
As in version 1.14.0 of popper.js the Export typings had been changed, which is now using Default Exports. 
See the changes as in the Commit of 26th February: 
https://github.com/FezVrasta/popper.js/commit/3315a6823f1685684fccf45f3fde407f1ca3716c#diff-01613ef3d5a6b03e140f807e6a8379bb