### PR TITLE
fix(build): fix cjs index exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 // @flow
-export { default as Popper, placements } from './Popper';
-export { default as Manager } from './Manager';
-export { default as Reference } from './Reference';
+import Popper, { placements } from './Popper';
+import Manager from './Manager';
+import Reference from './Reference';
+
+export { Popper, placements, Manager, Reference };


### PR DESCRIPTION
This fixes how the files gets transpiled; allowing rollup to determine the exports.

## Current: 
```javascript
'use strict';

Object.defineProperty(exports, "__esModule", {
  value: true
});

var _Popper = require('./Popper');

Object.defineProperty(exports, 'Popper', {
  enumerable: true,
  get: function get() {
    return _interopRequireDefault(_Popper).default;
  }
});
Object.defineProperty(exports, 'placements', {
  enumerable: true,
  get: function get() {
    return _Popper.placements;
  }
});

var _Manager = require('./Manager');

Object.defineProperty(exports, 'Manager', {
  enumerable: true,
  get: function get() {
    return _interopRequireDefault(_Manager).default;
  }
});

var _Reference = require('./Reference');

Object.defineProperty(exports, 'Reference', {
  enumerable: true,
  get: function get() {
    return _interopRequireDefault(_Reference).default;
  }
});

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
```

## Proposed:
```javascript
'use strict';

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.Reference = exports.Manager = exports.placements = exports.Popper = undefined;

var _Popper = require('./Popper');

var _Popper2 = _interopRequireDefault(_Popper);

var _Manager = require('./Manager');

var _Manager2 = _interopRequireDefault(_Manager);

var _Reference = require('./Reference');

var _Reference2 = _interopRequireDefault(_Reference);

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

exports.Popper = _Popper2.default;
exports.placements = _Popper.placements;
exports.Manager = _Manager2.default;
exports.Reference = _Reference2.default;
```